### PR TITLE
Prevent null element in schemas with ignored fields

### DIFF
--- a/bqschema_suite_test.go
+++ b/bqschema_suite_test.go
@@ -1,10 +1,10 @@
-package bqschema_test
+package bqschema
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestBqschema(t *testing.T) {

--- a/toSchema_test.go
+++ b/toSchema_test.go
@@ -1,13 +1,12 @@
-package bqschema_test
+package bqschema
 
 import (
-	"github.com/SeanDolphin/bqschema"
-	"google.golang.org/api/bigquery/v2"
-
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"google.golang.org/api/bigquery/v2"
 )
 
 var _ = Describe("ToSchema", func() {
@@ -623,7 +622,7 @@ var _ = Describe("ToSchema", func() {
 			object := data[0]
 			schema := data[1]
 			It(data[2].(string), func() {
-				result, err := bqschema.ToSchema(object)
+				result, err := ToSchema(object)
 				Expect(err).To(BeNil())
 				Expect(*result).To(Equal(schema))
 			})
@@ -634,22 +633,22 @@ var _ = Describe("ToSchema", func() {
 		table := [][]interface{}{
 			[]interface{}{
 				1,
-				bqschema.NotStruct,
+				NotStruct,
 				"not convert ints to schema",
 			},
 			[]interface{}{
 				1.0,
-				bqschema.NotStruct,
+				NotStruct,
 				"not convert floats to schema",
 			},
 			[]interface{}{
 				"some string",
-				bqschema.NotStruct,
+				NotStruct,
 				"not convert strings to schema",
 			},
 			[]interface{}{
 				false,
-				bqschema.NotStruct,
+				NotStruct,
 				"not convert  bools schema",
 			},
 		}
@@ -657,7 +656,7 @@ var _ = Describe("ToSchema", func() {
 			object := data[0]
 			expectedError := data[1]
 			It(data[2].(string), func() {
-				_, err := bqschema.ToSchema(object)
+				_, err := ToSchema(object)
 				Expect(err).NotTo(BeNil())
 				Expect(err).To(Equal(expectedError))
 			})

--- a/toSchema_test.go
+++ b/toSchema_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/SeanDolphin/bqschema"
 	"google.golang.org/api/bigquery/v2"
 
-	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -47,6 +46,22 @@ var _ = Describe("ToSchema", func() {
 					},
 				},
 				"should convert simple structs",
+			},
+			[]interface{}{
+				struct {
+					Included string
+					Excluded string `json:"-"`
+				}{},
+				bigquery.TableSchema{
+					Fields: []*bigquery.TableFieldSchema{
+						&bigquery.TableFieldSchema{
+							Mode: "required",
+							Name: "Included",
+							Type: "string",
+						},
+					},
+				},
+				`should ignore struct fields when the field's tag is "-"`,
 			},
 			[]interface{}{
 				struct {
@@ -610,7 +625,7 @@ var _ = Describe("ToSchema", func() {
 			It(data[2].(string), func() {
 				result, err := bqschema.ToSchema(object)
 				Expect(err).To(BeNil())
-				Expect(reflect.DeepEqual(schema, *result)).To(BeTrue())
+				Expect(*result).To(Equal(schema))
 			})
 		}
 	})
@@ -640,11 +655,11 @@ var _ = Describe("ToSchema", func() {
 		}
 		for _, data := range table {
 			object := data[0]
-			exceptedError := data[1]
+			expectedError := data[1]
 			It(data[2].(string), func() {
 				_, err := bqschema.ToSchema(object)
 				Expect(err).NotTo(BeNil())
-				Expect(err).To(Equal(exceptedError))
+				Expect(err).To(Equal(expectedError))
 			})
 		}
 	})

--- a/toStructs.go
+++ b/toStructs.go
@@ -1,13 +1,11 @@
 package bqschema
 
 import (
-	"google.golang.org/api/bigquery/v2"
-
 	"reflect"
 	"strconv"
 	"strings"
 
-	// "log"
+	"google.golang.org/api/bigquery/v2"
 )
 
 func ToStructs(result *bigquery.QueryResponse, dst interface{}) error {

--- a/toStructs_test.go
+++ b/toStructs_test.go
@@ -1,13 +1,12 @@
-package bqschema_test
+package bqschema
 
 import (
-	"github.com/SeanDolphin/bqschema"
-	"google.golang.org/api/bigquery/v2"
-
 	"reflect"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"google.golang.org/api/bigquery/v2"
 )
 
 var _ = Describe("ToStructs", func() {
@@ -76,7 +75,7 @@ var _ = Describe("ToStructs", func() {
 
 			var dst []test1
 
-			err := bqschema.ToStructs(response, &dst)
+			err := ToStructs(response, &dst)
 			Expect(err).To(BeNil())
 			Expect(reflect.DeepEqual(expectedResult, dst)).To(BeTrue())
 		})
@@ -145,7 +144,7 @@ var _ = Describe("ToStructs", func() {
 
 			var dst []test2
 
-			err := bqschema.ToStructs(response, &dst)
+			err := ToStructs(response, &dst)
 			Expect(err).To(BeNil())
 			Expect(reflect.DeepEqual(expectedResult, dst)).To(BeTrue())
 		})
@@ -234,7 +233,7 @@ var _ = Describe("ToStructs", func() {
 
 			var dst []test3
 
-			err := bqschema.ToStructs(response, &dst)
+			err := ToStructs(response, &dst)
 			Expect(err).To(BeNil())
 			Expect(reflect.DeepEqual(expectedResult, dst)).To(BeTrue())
 		})
@@ -313,7 +312,7 @@ var _ = Describe("ToStructs", func() {
 
 			var dst []test4
 
-			err := bqschema.ToStructs(response, &dst)
+			err := ToStructs(response, &dst)
 			Expect(err).To(BeNil())
 			Expect(reflect.DeepEqual(expectedResult, dst)).To(BeTrue())
 		})


### PR DESCRIPTION
Hi, thanks for your library! I'm finding it very helpful.

I needed to include a helper object into a struct from which I was creating a schema. On this field, I added the tag `json:"-"` to allow both `encoding/json` and `bqschema` to ignore it. Unfortunately, the JSON output of the schema then includes a `null` in the `"fields"` array corresponding to this ignored field.

I fixed this behavior in `8fa16a0` and made a few minor cleanups in the following commit. (They prevent needing to import the package in the tests.)

Hoping you'll find these changes amenable.

Cheers,
**—cw**
