### PR TITLE
Ignore unexported fields in schema, like encoding/json does

### DIFF
--- a/toSchema.go
+++ b/toSchema.go
@@ -25,6 +25,9 @@ func ToSchema(src interface{}) (*bigquery.TableSchema, error) {
 		schema.Fields = make([]*bigquery.TableFieldSchema, 0, t.NumField())
 		for i := 0; i < t.NumField(); i++ {
 			sf := t.Field(i)
+			if sf.PkgPath != "" { // unexported
+				continue
+			}
 			v := pointerGuard(value.Field(i))
 
 			var name string

--- a/toSchema_test.go
+++ b/toSchema_test.go
@@ -48,8 +48,9 @@ var _ = Describe("ToSchema", func() {
 			},
 			[]interface{}{
 				struct {
-					Included string
-					Excluded string `json:"-"`
+					Included   string
+					Excluded   string `json:"-"`
+					unexported string
 				}{},
 				bigquery.TableSchema{
 					Fields: []*bigquery.TableFieldSchema{
@@ -60,7 +61,7 @@ var _ = Describe("ToSchema", func() {
 						},
 					},
 				},
-				`should ignore struct fields when the field's tag is "-"`,
+				`should ignore struct fields when the field's tag is "-" or the field is not exported`,
 			},
 			[]interface{}{
 				struct {


### PR DESCRIPTION
This makes the BigQuery schema for a struct more consistent with its output from `encoding/json` since unexported fields are not serialized to JSON by the stdlib.
