### PR TITLE
Safer nulls and json tags for ToStructs

### DIFF
--- a/toStructs.go
+++ b/toStructs.go
@@ -34,6 +34,10 @@ func ToStructs(result *bigquery.QueryResponse, dst interface{}) error {
 				if field.IsValid() {
 					switch field.Kind() {
 					case reflect.Float64, reflect.Float32:
+						if cell.V == nil {
+							field.SetFloat(0)
+							continue
+						}
 						f, err := strconv.ParseFloat(cell.V.(string), 64)
 						if err == nil {
 							field.SetFloat(f)
@@ -41,6 +45,10 @@ func ToStructs(result *bigquery.QueryResponse, dst interface{}) error {
 							return err
 						}
 					case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+						if cell.V == nil {
+							field.SetInt(0)
+							continue
+						}
 						i, err := strconv.ParseInt(cell.V.(string), 10, 64)
 						if err == nil {
 							field.SetInt(i)
@@ -48,6 +56,10 @@ func ToStructs(result *bigquery.QueryResponse, dst interface{}) error {
 							return err
 						}
 					case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+						if cell.V == nil {
+							field.SetUint(0)
+							continue
+						}
 						i, err := strconv.ParseUint(cell.V.(string), 10, 64)
 						if err == nil {
 							field.SetUint(i)
@@ -56,6 +68,10 @@ func ToStructs(result *bigquery.QueryResponse, dst interface{}) error {
 						}
 
 					case reflect.Bool:
+						if cell.V == nil {
+							field.SetBool(false)
+							continue
+						}
 						b, err := strconv.ParseBool(cell.V.(string))
 						if err == nil {
 							field.SetBool(b)
@@ -63,6 +79,10 @@ func ToStructs(result *bigquery.QueryResponse, dst interface{}) error {
 							return err
 						}
 					case reflect.String:
+						if cell.V == nil {
+							field.SetString("")
+							continue
+						}
 						field.Set(reflect.ValueOf(cell.V))
 					}
 

--- a/toStructs.go
+++ b/toStructs.go
@@ -19,7 +19,17 @@ func ToStructs(result *bigquery.QueryResponse, dst interface{}) error {
 
 	for i := 0; i < itemType.NumField(); i++ {
 		field := itemType.Field(i)
-		nameMap[strings.ToLower(field.Name)] = field.Name
+		jsonTag := field.Tag.Get("json")
+		switch jsonTag {
+		case "-":
+			continue
+		case "":
+			nameMap[strings.ToLower(field.Name)] = field.Name
+		default:
+			jsonName := strings.Split(jsonTag, ",")[0]
+			nameMap[jsonName] = field.Name
+		}
+
 	}
 
 	items := reflect.MakeSlice(value.Type(), rowCount, rowCount)

--- a/toStructs_test.go
+++ b/toStructs_test.go
@@ -317,5 +317,74 @@ var _ = Describe("ToStructs", func() {
 			Expect(reflect.DeepEqual(expectedResult, dst)).To(BeTrue())
 		})
 
+		It("will handle nullable fields", func() {
+			response := &bigquery.QueryResponse{
+				Schema: &bigquery.TableSchema{
+					Fields: []*bigquery.TableFieldSchema{
+						&bigquery.TableFieldSchema{
+							Mode: "NULLABLE",
+							Name: "i",
+							Type: "INTEGER",
+						},
+						&bigquery.TableFieldSchema{
+							Mode: "NULLABLE",
+							Name: "s",
+							Type: "STRING",
+						},
+						&bigquery.TableFieldSchema{
+							Mode: "NULLABLE",
+							Name: "f",
+							Type: "FLOAT",
+						},
+						&bigquery.TableFieldSchema{
+							Mode: "NULLABLE",
+							Name: "b",
+							Type: "BOOLEAN",
+						},
+					},
+				},
+				Rows: []*bigquery.TableRow{
+					&bigquery.TableRow{
+						F: []*bigquery.TableCell{
+							&bigquery.TableCell{
+								V: nil,
+							},
+							&bigquery.TableCell{
+								V: nil,
+							},
+							&bigquery.TableCell{
+								V: nil,
+							},
+							&bigquery.TableCell{
+								V: nil,
+							},
+						},
+					},
+				},
+			}
+
+			type test5 struct {
+				I int
+				S string
+				F float32
+				B bool
+			}
+
+			expectedResult := []test5{
+				test5{
+					I: 0,
+					S: "",
+					F: 0.0,
+					B: false,
+				},
+			}
+
+			var dst []test5
+
+			err := ToStructs(response, &dst)
+			Expect(err).To(BeNil())
+			Expect(reflect.DeepEqual(expectedResult, dst)).To(BeTrue())
+		})
+
 	})
 })

--- a/toStructs_test.go
+++ b/toStructs_test.go
@@ -149,6 +149,75 @@ var _ = Describe("ToStructs", func() {
 			Expect(reflect.DeepEqual(expectedResult, dst)).To(BeTrue())
 		})
 
+		It("will fill an array of structs of simple types whos names match the JSON tag", func() {
+			response := &bigquery.QueryResponse{
+				Schema: &bigquery.TableSchema{
+					Fields: []*bigquery.TableFieldSchema{
+						&bigquery.TableFieldSchema{
+							Mode: "required",
+							Name: "alpha",
+							Type: "INTEGER",
+						},
+						&bigquery.TableFieldSchema{
+							Mode: "required",
+							Name: "beta",
+							Type: "FLOAT",
+						},
+						&bigquery.TableFieldSchema{
+							Mode: "required",
+							Name: "gamma",
+							Type: "STRING",
+						},
+						&bigquery.TableFieldSchema{
+							Mode: "required",
+							Name: "delta",
+							Type: "BOOLEAN",
+						},
+					},
+				},
+				Rows: []*bigquery.TableRow{
+					&bigquery.TableRow{
+						F: []*bigquery.TableCell{
+							&bigquery.TableCell{
+								V: "1",
+							},
+							&bigquery.TableCell{
+								V: "2.0",
+							},
+							&bigquery.TableCell{
+								V: "some",
+							},
+							&bigquery.TableCell{
+								V: "false",
+							},
+						},
+					},
+				},
+			}
+
+			type test1 struct {
+				A int     `json:"alpha"`
+				B float64 `json:"beta"`
+				C string  `json:"gamma"`
+				D bool    `json:"delta"`
+			}
+
+			expectedResult := []test1{
+				test1{
+					A: 1,
+					B: 2.0,
+					C: "some",
+					D: false,
+				},
+			}
+
+			var dst []test1
+
+			err := ToStructs(response, &dst)
+			Expect(err).To(BeNil())
+			Expect(reflect.DeepEqual(expectedResult, dst)).To(BeTrue())
+		})
+
 		It("will fill an array of structs of non standard types", func() {
 			response := &bigquery.QueryResponse{
 				Schema: &bigquery.TableSchema{


### PR DESCRIPTION
This won't panic if the queryresult has null values.

Additionally, users can supply json tags in their incoming struct of the big query field names.
